### PR TITLE
Workaround for incorrect sys-images paths.

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -15,7 +15,7 @@
 #
 # Copyright 2012 MaestroDev, unless otherwise noted.
 #
-define android::package($type) {
+define android::package($type, $expected_path = undef) {
   include android
 
   if ( $::id == 'root' ) {
@@ -25,32 +25,46 @@ define android::package($type) {
   $proxy_host = $android::proxy_host ? { undef => '', default => "--proxy-host ${android::proxy_host}" }
   $proxy_port = $android::proxy_port ? { undef => '', default => "--proxy-port ${android::proxy_port}" }
 
-  case $type {
-    'platform-tools': {
-      $creates = "${android::paths::sdk_home}/platform-tools"
+  if ($expected_path == undef) {
+    case $type {
+      'platform-tools': {
+        $creates = "${android::paths::sdk_home}/platform-tools"
+      }
+      'platform': {
+        $creates = "${android::paths::sdk_home}/platforms/${title}"
+      }
+      'system-images': {
+        # Note that this is a bit broken since the sdk puts the system images in paths like this:
+        # sys-img-x86-android-19                          -> system-images/android-19/default/armeabi-v7a
+        # sys-img-armeabi-v7a-addon-google_apis-google-22 -> system-images/android-22/google_apis/armeabi-v7a
+        # sys-img-x86-addon-google_apis-google-22         -> system-images/android-22/google_apis/x86
+        # The $expected_path parameter is a bit of a hack to support unexpected install locations.
+        $title_parts = split($title, '-')
+        if size($title_parts) > 5 {
+          # 8
+          $creates = "${android::paths::sdk_home}/system-images/android-${title_parts[7]}"
+        } else {
+          # 5
+          $creates = "${android::paths::sdk_home}/system-images/android-${title_parts[4]}/default/${title_parts[2]}"
+        }
+      }
+      'addon': {
+        $creates = "${android::paths::sdk_home}/add-ons/${title}"
+      }
+      'extra': {
+        $title_parts = split($title, '-')
+        $creates = "${android::paths::sdk_home}/extras/${title_parts[1]}/${title_parts[2]}"
+      }
+      'build-tools': {
+        $title_parts = split($title, '-')
+        $creates = "${android::paths::sdk_home}/build-tools/${title_parts[2]}"
+      }
+      default: {
+        fail("Unsupported package type: ${type}")
+      }
     }
-    'platform': {
-      $creates = "${android::paths::sdk_home}/platforms/${title}"
-    }
-    'system-images': {
-      $title_parts = split($title, '-')
-      $creates = "${android::paths::sdk_home}/system-images/android-${title_parts[1]}"
-    }
-    'addon': {
-      $creates = "${android::paths::sdk_home}/add-ons/${title}"
-    }
-    'extra': {
-      $title_parts = split($title, '-')
-      $creates = "${android::paths::sdk_home}/extras/${title_parts[1]}/${title_parts[2]}"
-    }
-    'build-tools': {
-      $title_parts = split($title, '-')
-      
-      $creates = "${android::paths::sdk_home}/build-tools/${title_parts[2]}"
-    }
-    default: {
-      fail("Unsupported package type: ${type}")
-    }
+  } else {
+    $creates = "${android::installdir}/${expected_path}"
   }
 
   file { "${android::installdir}/expect-install-${title}":

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -64,7 +64,7 @@ define android::package($type, $expected_path = undef) {
       }
     }
   } else {
-    $creates = "${android::installdir}/${expected_path}"
+    $creates = "${android::paths::sdk_home}/${expected_path}"
   }
 
   file { "${android::installdir}/expect-install-${title}":

--- a/manifests/system_images.pp
+++ b/manifests/system_images.pp
@@ -10,10 +10,11 @@
 #
 # Copyright 2013 Philip Schiffer
 #
-define android::system_images() {
+define android::system_images($expected_path = undef) {
 
   android::package{ $title:
-    type => 'system-images',
+    type          => 'system-images',
+    expected_path => $expected_path,
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "maestrodev-android",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "maestrodev",
   "summary": "Android SDK module for Puppet",
   "license": "Apache License, Version 2.0",


### PR DESCRIPTION
The Android system images do not install to the expected location (at
least on Darwin).  Add a workaround that allows the caller to specify
the expected install location.
